### PR TITLE
Fix: 'no function block' in device mappings

### DIFF
--- a/code/library/src/main/kotlin/org/fbme/lib/iec61499/parser/SystemConverter.kt
+++ b/code/library/src/main/kotlin/org/fbme/lib/iec61499/parser/SystemConverter.kt
@@ -59,8 +59,10 @@ class SystemConverter(arguments: ConverterArguments) : DeclarationConverterBase<
         val mappingElements = element.getChildren("Mapping")
         for (mappingElement in mappingElements) {
             val mapping = factory.createMapping()
-            mapping.applicationFBReference.setFQName(mappingElement.getAttributeValue("From"))
-            mapping.resourceFBReference.setFQName(mappingElement.getAttributeValue("To"))
+            val from = mappingElement.getAttributeValue("From")
+            val to = mappingElement.getAttributeValue("To").plus(".").plus(from.split(".")[1])
+            mapping.applicationFBReference.setFQName(from)
+            mapping.resourceFBReference.setFQName(to)
             mappings.add(mapping)
         }
     }


### PR DESCRIPTION
Fixed device mapping <no function block> in the nxt Importer.
<img width="553" alt="mapping-null" src="https://github.com/JetBrains/fbme/assets/49787583/33e49639-bec0-4ebd-bfb2-15b77d2b24d8">



